### PR TITLE
ODP-2415 Update oozie to use ODP jars for dependent projects

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,6 +152,11 @@
             <artifactId>hbase-client</artifactId>
              <scope>provided</scope>
         </dependency>
+                <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>
             <artifactId>hive-webhcat-java-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
          <spark.guava.version>14.0.1</spark.guava.version>
          <spark.scala.binary.version>2.10</spark.scala.binary.version>
          <sqoop.classifier>hadoop260</sqoop.classifier>
-         <tez.version>0.8.4</tez.version>
+         <tez.version>0.10.1.3.2.3.3-2</tez.version>
          <joda.time.version>2.9.9</joda.time.version>
          <avro.version>1.8.2</avro.version>
 	 <open.oozie.version>5.2.1</open.oozie.version>
@@ -2225,8 +2225,8 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <spark.version>2.1.0</spark.version>
-                <spark.streaming.kafka.version>1.6.2</spark.streaming.kafka.version>
+                <spark.version>2.4.8.3.2.3.3-2</spark.version>
+                <spark.streaming.kafka.version>2.4.8.3.2.3.3-2</spark.streaming.kafka.version>
                 <spark.bagel.version>1.6.2</spark.bagel.version>
             </properties>
         </profile>


### PR DESCRIPTION
Update oozie to use ODP jars for dependent projects primarily hadoop, hbase, spark, and tez. Updating hbase version caused a compilation error with CNF, which was resolved by adding hbase-server jar dependency in oozie-core.


Compilation successful on local build machine using `bin/mkdistro.sh -DskipTests -Phadoop-3 -Pspark-2 -Puber -Dzookeeper.version=3.5.10.3.2.3.3-2 -Dhadoop.version=3.2.3.3.2.3.3-2 -Dhadoop.auth.version=3.2.3.3.2.3.3-2 -Dhive.version=3.1.4.3.2.3.3-2 -Dsqoop.version=1.4.7 -Dspark.version=2.4.8.3.2.3.3-2 -Dspark.scala.binary.version=2.11 -Djackson.version=2.9.10 -Dmaven.repo.local=${HOME}/.m2/repository -Dmaven.test.skip=true`