### PR TITLE
ODP-3117: Add parameter "oozie.ui.enabled". When set to false, the Oozie UI will be complete disabled, the Oozie server will not even expose the UI resources.

### DIFF
--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -121,6 +121,12 @@
         </description>
     </property>
 
+    <property>
+      <name>oozie.ui.enabled</name>
+      <value>true</value>
+      <description>When set to false, the Oozie UI will be complete disabled, the Oozie server will not even expose the UI resources</description>
+    </property>
+
     <!-- Services -->
 
     <property>

--- a/server/src/main/java/org/apache/oozie/server/WebRootResourceLocator.java
+++ b/server/src/main/java/org/apache/oozie/server/WebRootResourceLocator.java
@@ -22,15 +22,21 @@ import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import org.apache.oozie.service.ConfigurationService;
 
 public class WebRootResourceLocator {
     private static final String WEBROOT_INDEX = "/webapp/";
+    private static final String WEBROOT_NO_UI_INDEX = "/webapp/no-ui";
 
     public URI getWebRootResourceUri() throws FileNotFoundException, URISyntaxException
     {
-        URL indexUri = JspHandler.class.getResource(WebRootResourceLocator.WEBROOT_INDEX);
-        if (indexUri == null)
-        {
+        URL indexUri;
+        if (ConfigurationService.getBoolean("oozie.ui.enabled", true)) {
+            indexUri = JspHandler.class.getResource(WebRootResourceLocator.WEBROOT_INDEX);
+        } else {
+            indexUri = JspHandler.class.getResource(WebRootResourceLocator.WEBROOT_NO_UI_INDEX);
+        }
+        if (indexUri == null) {
             throw new FileNotFoundException("Unable to find resource " + WebRootResourceLocator.WEBROOT_INDEX);
         }
         // Points to wherever /webroot/ (the resource) is

--- a/webapp/src/main/webapp/no-ui/index.jsp
+++ b/webapp/src/main/webapp/no-ui/index.jsp
@@ -17,6 +17,6 @@
 -->
 <html>
     <body>
-        UI is disabled, please contact the administrator.
+        UI access is currently disabled. For assistance, please reach out to the system administrator.
     </body>
 </html>

--- a/webapp/src/main/webapp/no-ui/index.jsp
+++ b/webapp/src/main/webapp/no-ui/index.jsp
@@ -1,0 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html>
+    <body>
+        UI is disabled, please contact the administrator.
+    </body>
+</html>


### PR DESCRIPTION
When `oozie.ui.enabled=false` this is how the page will look:

<img width="1341" alt="image" src="https://github.com/user-attachments/assets/8b1b5e63-8ad7-40bc-b3c8-762dd8b9bc29" />
