### PR TITLE
ODP-3191 -  Excluding Log4j from Hbase-server module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -176,6 +176,12 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-server</artifactId>
             <version>${hbase.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>


### PR DESCRIPTION
ODP-3191 -  Excluding Log4j from Hbase-server module