### PR TITLE
ODP-3945 : Remove open.oozie.version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -463,7 +463,6 @@
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-fluent-job-api</artifactId>
             <classifier>tests</classifier>
-            <version>${open.oozie.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-	    <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/fluent-job/fluent-job-client/pom.xml
+++ b/fluent-job/fluent-job-client/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-            <version>${open.oozie.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -48,7 +47,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-           <version>${open.oozie.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>
@@ -81,13 +79,11 @@
         <dependency>
             <groupId>org.apache.oozie.test</groupId>
             <artifactId>oozie-mini</artifactId>
-            <version>${open.oozie.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.oozie.test</groupId>
             <artifactId>oozie-mini</artifactId>
-            <version>${open.oozie.version}</version>
              <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/minitest/pom.xml
+++ b/minitest/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-            <version>${open.oozie.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -48,7 +47,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-            <version>${open.oozie.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
          <tez.version>0.10.3.3.3.6.1-1</tez.version>
          <joda.time.version>2.13.1</joda.time.version>
          <avro.version>1.12.0</avro.version>
-        <open.oozie.version>5.2.1.3.3.6.1-1</open.oozie.version>
 
          <jetty.version>9.4.56.v20240826</jetty.version>
          <apache.jsp.version>8.0.33</apache.jsp.version>

--- a/sharelib/git/pom.xml
+++ b/sharelib/git/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-  	   <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/hive/pom.xml
+++ b/sharelib/hive/pom.xml
@@ -192,7 +192,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-            <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/hive2/pom.xml
+++ b/sharelib/hive2/pom.xml
@@ -240,7 +240,6 @@ e
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-  	    <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/pig/pom.xml
+++ b/sharelib/pig/pom.xml
@@ -90,7 +90,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
- 	    <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/spark/pom.xml
+++ b/sharelib/spark/pom.xml
@@ -248,7 +248,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-            <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -210,7 +210,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-              <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/sharelib/streaming/pom.xml
+++ b/sharelib/streaming/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-     	     <version>${open.oozie.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -67,7 +67,6 @@
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
             <classifier>tests</classifier>
-           <version>${open.oozie.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/zookeeper-security-tests/pom.xml
+++ b/zookeeper-security-tests/pom.xml
@@ -49,14 +49,12 @@
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
-             <version>${open.oozie.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
             <classifier>tests</classifier>
-             <version>${open.oozie.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This patch was tested locally.