### PR TITLE
ODP-3968 Revert derbyshared dependency for derby 10.14.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1531,13 +1531,6 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.derby</groupId>
-                <artifactId>derbyshared</artifactId>
-                <version>${derby.version}</version>
-                <scope>compile</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-jexl</artifactId>
                 <version>2.1.1</version>


### PR DESCRIPTION
ODP-3968 Revert derbyshared dependency as part of derby downgraded to 10.14.2.0 in previous commits. derbyshared dependency was introduced in derby 10.15.x onwards, hence failing builds when derby was changed to 10.14.2.0.

The patch is tested by building a fresh rpm and verifying oozie sanity checks in RHEL9 cluster for 3.3.6.1-1.