### PR TITLE
ODP-2760: Refactor Oozie to use ambari-python-wrap for all scripts

### DIFF
--- a/tools/src/main/bin/instrumentation-log-parser.py
+++ b/tools/src/main/bin/instrumentation-log-parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
ODP-2760: Refactor Oozie to use ambari-python-wrap for all scripts