### PR TITLE
ODP-5394 : Fix POM exclusion, properly exclude calcite-core in sqoop module

### DIFF
--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -167,6 +167,7 @@
                     <groupId>org.apache.accumulo</groupId>
                     <artifactId>accumulo-minicluster</artifactId>
                 </exclusion>
+                <exclusion>
                     <groupId>org.apache.calcite</groupId>
                     <artifactId>calcite-core</artifactId>
                 </exclusion>
@@ -314,4 +315,3 @@
     </build>
 
 </project>
-


### PR DESCRIPTION
https://accelcentral.atlassian.net/browse/ODP-5349