### PR TITLE
ODP-5363 | ODP-5169: SSL support with multiple SAN entries

### DIFF
--- a/server/src/main/java/org/apache/oozie/server/SSLServerConnectorFactory.java
+++ b/server/src/main/java/org/apache/oozie/server/SSLServerConnectorFactory.java
@@ -53,11 +53,11 @@ class SSLServerConnectorFactory {
     @VisibleForTesting
     static final long OOZIE_DEFAULT_HSTS_MAX_AGE = 31536000;
 
-    private SslContextFactory sslContextFactory;
+    private SslContextFactory.Server sslContextFactory;
     private Configuration conf;
 
     @Inject
-    public SSLServerConnectorFactory(final SslContextFactory sslContextFactory) {
+    public SSLServerConnectorFactory(final SslContextFactory.Server sslContextFactory) {
         this.sslContextFactory = Objects.requireNonNull(sslContextFactory,  "sslContextFactory is null");
     }
 

--- a/server/src/test/java/org/apache/oozie/server/TestSSLServerConnectorFactory.java
+++ b/server/src/test/java/org/apache/oozie/server/TestSSLServerConnectorFactory.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class TestSSLServerConnectorFactory {
-    @Mock private SslContextFactory mockSSLContextFactory;
+    @Mock private SslContextFactory.Server mockSSLContextFactory;
     @Mock private SSLServerConnectorFactory mockSSLServerConnectorFactory;
     @Spy  private Server mockServer;
     @Mock private ServerConnector mockServerConnector;


### PR DESCRIPTION
### Summary
To support multiple certificates in the keystore when SSL is enabled.

ODP-5363 Ticket : https://accelcentral.atlassian.net/browse/ODP-5363

OOZIE-3599 Upgrade Jetty to 9.4.43.v20210629 (medb via dionusos)
(partially cherry picked from commit b6575162a7979ee655c2397b8a5ba3153fc03ae9)

----
### Test