### PR TITLE
ODP-6403: Fixing hive-service missing jar issue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -563,7 +563,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Changing the Maven scope from "**test"** to **"compile"**  fixes a runtime failure in Oozie caused by an incorrect Maven dependency scope for hive-service.