### PR TITLE
OCR-2428 Support spark3 tags and resolve conflicting jar references

### DIFF
--- a/client/src/main/resources/spark3-action-0.1.xsd
+++ b/client/src/main/resources/spark3-action-0.1.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:spark3="uri:oozie:spark3-action:0.1" elementFormDefault="qualified"
+           targetNamespace="uri:oozie:spark3-action:0.1">
+
+    <xs:element name="spark3" type="spark3:ACTION"/>
+
+    <xs:complexType name="ACTION">
+        <xs:sequence>
+            <xs:element name="job-tracker" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="name-node" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="prepare" type="spark3:PREPARE" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="job-xml" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="configuration" type="spark3:CONFIGURATION" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="master" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="mode" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="jar" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="spark-opts" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CONFIGURATION">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="value" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PREPARE">
+        <xs:sequence>
+            <xs:element name="delete" type="spark3:DELETE" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="mkdir" type="spark3:MKDIR" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DELETE">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="MKDIR">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/client/src/main/resources/spark3-action-0.2.xsd
+++ b/client/src/main/resources/spark3-action-0.2.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:spark3="uri:oozie:spark3-action:0.2" elementFormDefault="qualified"
+           targetNamespace="uri:oozie:spark3-action:0.2">
+
+    <xs:element name="spark3" type="spark3:ACTION"/>
+
+    <xs:complexType name="ACTION">
+        <xs:sequence>
+            <xs:element name="job-tracker" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="name-node" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="prepare" type="spark3:PREPARE" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="job-xml" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="configuration" type="spark3:CONFIGURATION" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="master" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="mode" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="jar" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="spark-opts" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="file" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CONFIGURATION">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="value" minOccurs="1" maxOccurs="1" type="xs:string"/>
+                        <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PREPARE">
+        <xs:sequence>
+            <xs:element name="delete" type="spark3:DELETE" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="mkdir" type="spark3:MKDIR" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DELETE">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="MKDIR">
+        <xs:attribute name="path" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/client/src/main/resources/spark3-action-1.0.xsd
+++ b/client/src/main/resources/spark3-action-1.0.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:spark3="uri:oozie:spark3-action:1.0" elementFormDefault="qualified"
+           targetNamespace="uri:oozie:spark3-action:1.0">
+
+    <xs:include schemaLocation="oozie-common-1.0.xsd"/>
+
+    <xs:element name="spark3" type="spark3:ACTION"/>
+
+    <xs:complexType name="ACTION">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="job-tracker" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="resource-manager" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="name-node" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="prepare" type="spark3:PREPARE" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="launcher" type="spark3:LAUNCHER" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="job-xml" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="configuration" type="spark3:CONFIGURATION" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="master" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="mode" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="jar" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="spark-opts" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="arg" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="file" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="archive" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/core/src/main/java/org/apache/oozie/action/hadoop/Spark3ActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/Spark3ActionExecutor.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.oozie.action.hadoop;
+
+import org.jdom.Element;
+
+public class Spark3ActionExecutor extends SparkActionExecutor {
+
+    public Spark3ActionExecutor() {
+        super("spark3");
+    }
+
+    @Override
+    protected String getDefaultShareLibName(final Element actionXml) {
+        return "spark3";
+    }
+}

--- a/core/src/main/java/org/apache/oozie/action/hadoop/SparkActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/SparkActionExecutor.java
@@ -51,7 +51,11 @@ public class SparkActionExecutor extends JavaActionExecutor {
     private static final String HADOOP_CLIENT_CONF_DIR = "HADOOP_CLIENT_CONF_DIR";
 
     public SparkActionExecutor() {
-        super("spark");
+        this("spark");
+    }
+
+    protected SparkActionExecutor(final String actionType) {
+        super(actionType);
     }
 
     @Override

--- a/core/src/main/resources/oozie-default.xml
+++ b/core/src/main/resources/oozie-default.xml
@@ -1693,6 +1693,7 @@ will be the requeue interval for the actions which are waiting for a long time w
             oozie-sla-0.1.xsd,oozie-sla-0.2.xsd,
             hive2-action-0.1.xsd,hive2-action-0.2.xsd,hive2-action-1.0.xsd,
             spark-action-0.1.xsd,spark-action-0.2.xsd,spark-action-1.0.xsd,
+            spark3-action-0.1.xsd,spark3-action-0.2.xsd,spark3-action-1.0.xsd,
             git-action-1.0.xsd
         </value>
         <description>
@@ -1832,6 +1833,7 @@ will be the requeue interval for the actions which are waiting for a long time w
             org.apache.oozie.action.oozie.SubWorkflowActionExecutor,
             org.apache.oozie.action.email.EmailActionExecutor,
             org.apache.oozie.action.hadoop.SparkActionExecutor,
+            org.apache.oozie.action.hadoop.Spark3ActionExecutor,
             org.apache.oozie.action.hadoop.GitActionExecutor
         </value>
         <description>

--- a/core/src/test/java/org/apache/oozie/service/TestSchemaService.java
+++ b/core/src/test/java/org/apache/oozie/service/TestSchemaService.java
@@ -309,6 +309,32 @@ public class TestSchemaService extends XTestCase {
             "    <end name='end' />\n" +
             "</workflow-app>\n";
 
+    private static final String SPARK3_ACTION_LAUNCHER_CONF = "<workflow-app xmlns='uri:oozie:workflow:1.0' " +
+            "name='Spark3FileCopy'>\n" +
+            "    <start to='spark3-node' />\n" +
+            "    <action name='spark3-node'>\n" +
+            "        <spark3 xmlns=\"uri:oozie:spark3-action:1.0\">\n" +
+            "            <resource-manager>${resourceManager}</resource-manager>\n" +
+            "            <name-node>${nameNode}</name-node>\n" +
+            "            <master>yarn</master>\n" +
+            "            <mode>cluster</mode>\n" +
+            "            <name>Spark3-FileCopy</name>\n" +
+            "            <class>org.apache.oozie.example.SparkFileCopy</class>\n" +
+            "            <jar>${nameNode}/user/${wf:user()}/${examplesRoot}/apps/spark3/lib/oozie-examples.jar</jar>\n" +
+            "            <arg>${nameNode}/user/${wf:user()}/${examplesRoot}/input-data/text/data.txt</arg>\n" +
+            "            <arg>${nameNode}/user/${wf:user()}/${examplesRoot}/output-data/spark3</arg>\n" +
+            "        </spark3>\n" +
+            "        <ok to=\"end\" />\n" +
+            "        <error to=\"fail\" />\n" +
+            "    </action>\n" +
+            "    <kill name=\"fail\">\n" +
+            "        <message>Workflow failed, error\n" +
+            "            message[${wf:errorMessage(wf:lastErrorNode())}]\n" +
+            "        </message>\n" +
+            "    </kill>\n" +
+            "    <end name='end' />\n" +
+            "</workflow-app>\n";
+
     private SchemaService wss;
     private Validator workflowValidator;
     private Validator coordinatorValidator;
@@ -568,5 +594,9 @@ public class TestSchemaService extends XTestCase {
 
     public void testSparkActionLauncherConfig() throws Exception {
         workflowValidator.validate(new StreamSource(new StringReader(SPARK_ACTION_LAUNCHER_CONF)));
+    }
+
+    public void testSpark3ActionLauncherConfig() throws Exception {
+        workflowValidator.validate(new StreamSource(new StringReader(SPARK3_ACTION_LAUNCHER_CONF)));
     }
 }

--- a/sharelib/oozie/pom.xml
+++ b/sharelib/oozie/pom.xml
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <version>${spark3.commons.lang3.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/sharelib/spark3/pom.xml
+++ b/sharelib/spark3/pom.xml
@@ -418,6 +418,14 @@
                     <artifactId>hadoop-client</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.spark-project.hive</groupId>
                     <artifactId>hive-beeline</artifactId>
                 </exclusion>

--- a/sharelib/spark3/pom.xml
+++ b/sharelib/spark3/pom.xml
@@ -89,19 +89,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- Hadoop client split JARs required by Spark3 YARN AM -->
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client-runtime</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-web-proxy</artifactId>
@@ -137,6 +124,20 @@
             <version>${spark3.jackson.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- reload4j and its SLF4J binding conflict with log4j-1.2-api (Log4j2 bridge);
+     mark provided so they are excluded from the sharelib assembly -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-sharelib-oozie</artifactId>
@@ -286,6 +287,12 @@
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/sharelib/spark3/pom.xml
+++ b/sharelib/spark3/pom.xml
@@ -155,6 +155,14 @@
                     <artifactId>hadoop-client</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.spark-project.hive</groupId>
                     <artifactId>hive-beeline</artifactId>
                 </exclusion>

--- a/sharelib/spark3/pom.xml
+++ b/sharelib/spark3/pom.xml
@@ -135,6 +135,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
+            <version>1.7.35</version>
             <scope>provided</scope>
         </dependency>
 

--- a/sharelib/spark3/pom.xml
+++ b/sharelib/spark3/pom.xml
@@ -237,6 +237,14 @@
                     <artifactId>hadoop-annotations</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.spark-project.hive</groupId>
                     <artifactId>hive-beeline</artifactId>
                 </exclusion>


### PR DESCRIPTION
OCR-2428 [Remove hadoop-client-api and hadoop-client-runtime and mark reload4j and slf4j-reload4j as provided in spark3 sharelib to avoid conflict errors