### PR TITLE
OCR-2439 Fix missing hadoop-shaded-avro dependency for shell action execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1893,6 +1893,12 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.4</version>
             </dependency>
+            
+            <dependency>
+                <groupId>org.apache.hadoop.thirdparty</groupId>
+                <artifactId>hadoop-shaded-avro_1_11</artifactId>
+                <version>1.4.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/sharelib/oozie/pom.xml
+++ b/sharelib/oozie/pom.xml
@@ -61,6 +61,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-avro_1_11</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <exclusions>


### PR DESCRIPTION
OCR-2439 Fix missing Hadoop-shaded-avro dependency for shell action execution


Patch tested with local build.