### PR TITLE
OSV CVE fixes on Oozie for 3.2.3.6-2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -564,6 +564,10 @@
                     <groupId>com.mchange</groupId>
                     <artifactId>c3p0</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>mchange-commons-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -612,6 +612,12 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.pac4j</groupId>
+                    <artifactId>pac4j-saml-opensamlv3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -559,6 +559,12 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.mchange</groupId>
+                    <artifactId>c3p0</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -102,11 +102,12 @@
             </exclusions>
         </dependency>
 
+        <!-- OSV-18467 Remove pig module from ooziesharelib for now as it is not included in ODP stack to exclude pig package CVEs
         <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-sharelib-pig</artifactId>
             <scope>compile</scope>
-        </dependency>
+        </dependency-->
 
         <dependency>
             <groupId>org.apache.oozie</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -212,6 +212,16 @@
                     </descriptors>
                 </configuration>
             </plugin>
+             <!-- OSV-18467 Remove pig module from ooziesharelib for now as it is not included in ODP stack to exclude pig package CVEs-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/example/DemoPigMain.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/sharelib/pom.xml
+++ b/sharelib/pom.xml
@@ -34,7 +34,8 @@
     <modules>
         <module>streaming</module>
         <module>hcatalog</module>
-        <module>pig</module>
+        <!-- OSV-18467 Remove pig module from ooziesharelib for now as it is not included in ODP stack to exclude pig package CVEs>
+        <module>pig</module-->
         <module>git</module>
         <module>hive</module>
         <module>hive2</module>

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -96,6 +96,10 @@
                     <artifactId>servlet-api-2.5</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-runner</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>javax.servlet.jsp</groupId>
                     <artifactId>jsp-api</artifactId>
                 </exclusion>

--- a/src/main/assemblies/sharelib.xml
+++ b/src/main/assemblies/sharelib.xml
@@ -30,10 +30,11 @@
     </files>
 
     <fileSets>
+        <!-- OSV-18467 Remove pig module from ooziesharelib for now as it is not included in ODP stack to exclude pig package CVEs
         <fileSet>
             <directory>${basedir}/pig/target/partial-sharelib</directory>
             <outputDirectory>/</outputDirectory>
-        </fileSet>
+        </fileSet-->
         <fileSet>
             <directory>${basedir}/streaming/target/partial-sharelib</directory>
             <outputDirectory>/</outputDirectory>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -227,10 +227,11 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!-- OSV-18467 Remove pig module from ooziesharelib for now as it is not included in ODP stack to exclude pig package CVEs
                                 <artifactItem>
                                     <groupId>org.apache.oozie</groupId>
                                     <artifactId>oozie-sharelib-pig</artifactId>
-                                </artifactItem>
+                                </artifactItem-->
                                 <artifactItem>
                                     <groupId>org.apache.oozie</groupId>
                                     <artifactId>oozie-sharelib-hive</artifactId>


### PR DESCRIPTION
OSV-18679 Fix CVE-2020-10683 from transitive dependency dom4j-1.6.1
OSV-18611 Fix CVE-2026-27830 from transitive dependency mchange_c3p0
OSV-18622 Fix CVE-2026-27727 from transitive dependency mchange-commons-java
OSV-18465|OSV-18464|OSV-18463|OSV-18462|OSV-18461 Exclude unwanted jetty runner to address critical mina-core CVEs
OSV-18467 Remove pig module from ooziesharelib to exclude pig package CVEs