### PR TITLE
OSV-21996 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
          <derby.version>10.14.2.0</derby.version>
          <xerces.version>2.11.0</xerces.version>
          <curator.version>5.2.0</curator.version>
-         <jackson.version>2.15.2</jackson.version>
+         <jackson.version>2.18.6</jackson.version>
          <log4j.version>1.2.17</log4j.version>
          <reload4j.version>1.2.25</reload4j.version>
          <activemq.version>5.15.9</activemq.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-21996, OSV-22009, OSV-22029, OSV-22051