### PR TITLE
OSV-21820 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     </organization>
 
     <properties>
+        <log4j2.version>2.25.4</log4j2.version>
         <odp.release.version>3.3.6.5-SNAPSHOT</odp.release.version>
         <targetJavaVersion>11</targetJavaVersion>
         <sourceJavaVersion>11</sourceJavaVersion>
@@ -237,6 +238,33 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- CVE_LOG4J_FORCE -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-web</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.oozie</groupId>
                 <artifactId>oozie-client</artifactId>


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-21820, OSV-21825, OSV-21826, OSV-21827, OSV-21828, OSV-21829