### PR TITLE
OSV-21822 - CVE - Bumped-up batik/xmlgraphics/xalan/c3p0/jgit to address Oozie-owned CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,12 @@
          <httpclient.version>4.5.14</httpclient.version>
          <kyro.version>2.22</kyro.version>
          <javax.servlet.api.version>3.0.1</javax.servlet.api.version>
-         <jgit.version>5.0.1.201806211838-r</jgit.version>
+         <jgit.version>5.13.4.202507202350-r</jgit.version>
+         <mchange.commons.version>0.4.0</mchange.commons.version>
+         <c3p0.version>0.12.0</c3p0.version>
+         <xalan.version>2.7.3</xalan.version>
+         <xmlgraphics.commons.version>2.6</xmlgraphics.commons.version>
+         <batik.version>1.17</batik.version>
          <spotbugs.annotations.version>3.1.11</spotbugs.annotations.version>
          <spotbugs-maven-plugin.version>3.1.11</spotbugs-maven-plugin.version>
          <spotbugs.version>3.1.11</spotbugs.version>
@@ -1836,6 +1841,11 @@
                 <artifactId>org.eclipse.jgit.http.server</artifactId>
                 <version>${jgit.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+                <version>${jgit.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>dk.brics.automaton</groupId>
@@ -1946,6 +1956,134 @@
                 <artifactId>hadoop-shaded-avro_1_11</artifactId>
                 <version>1.4.0</version>
             </dependency>
+
+            <!-- CVE bumps: batik/xmlgraphics/xalan/c3p0/mchange (OSV-21822 et al.) -->
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-anim</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-awt-util</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-bridge</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-codec</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-constants</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-css</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-dom</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-ext</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-gvt</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-i18n</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-parser</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-rasterizer</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-script</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-svg-dom</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-svggen</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-svgrasterizer</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-transcoder</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-util</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-xml</artifactId>
+                <version>${batik.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>xmlgraphics-commons</artifactId>
+                <version>${xmlgraphics.commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>${xalan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>serializer</artifactId>
+                <version>${xalan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>${xalan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>c3p0</artifactId>
+                <version>${c3p0.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mchange</groupId>
+                <artifactId>mchange-commons-java</artifactId>
+                <version>${mchange.commons.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/sharelib/git/pom.xml
+++ b/sharelib/git/pom.xml
@@ -103,6 +103,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.jsch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.http.server</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
- batik.* : 1.10 -> 1.17 (covers OSV-21822/21823/21824/22005/22008/22055)
- xmlgraphics-commons : 2.3 -> 2.6 (OSV-22024)
- xalan : 2.7.2 -> 2.7.3 (OSV-21983)
- c3p0 : 0.9.5.4 -> 0.12.0 (OSV-21978)
- mchange-commons-java : 0.2.15 -> 0.4.0 (OSV-22037)
- jgit : 5.0.1 -> 5.13.4.202507202350-r + org.eclipse.jgit.ssh.jsch (OSV-21841, OSV-21842)
- Tickets : OSV-21822, OSV-21823, OSV-21824, OSV-22008, OSV-22005, OSV-22055, OSV-21978, OSV-22037, OSV-21842, OSV-21841, OSV-21983, OSV-22024
- Component: oozie (nightly/ODP-3.3.6.5)