### PR TITLE
OCR-2572 - Bug - Exclude Log4j2 bridge, old libthrift and jline from Sqoop/HCatalog sharelibs

### DIFF
--- a/sharelib/hcatalog/pom.xml
+++ b/sharelib/hcatalog/pom.xml
@@ -69,6 +69,11 @@
                     <groupId>org.apache.thrift</groupId>
                     <artifactId>libthrift</artifactId>
                 </exclusion>
+                <!-- OCR-2571: jline 0.9.94 from Oozie BOM breaks Beeline when hcatalog is merged into hive2 -->
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper</artifactId>

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -76,6 +76,11 @@
                     <groupId>org.apache.thrift</groupId>
                     <artifactId>thrift</artifactId>
                 </exclusion>
+                <!-- OCR-2571: old libthrift (e.g. 0.9.3) breaks Hive Metastore 0.16.0 TSocket API -->
+                <exclusion>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>libthrift</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
@@ -91,6 +96,28 @@
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <!-- OCR-2571: Log4j2 bridge + reload4j on same CP causes LogEventAdapter VerifyError -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-web</artifactId>
+                </exclusion>
+                <!-- OCR-2571: avoid shipping obsolete jline 0.9.94 into sqoop sharelib -->
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.mortbay.jetty</groupId>
@@ -177,6 +204,13 @@
                     <artifactId>logback-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Align thrift with Hive Metastore (0.16.0) after excluding transitive old libthrift -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.16.0</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Summary
- Exclude `log4j-1.2-api` / `log4j-api` / `log4j-core` / `log4j-web` from Sqoop sharelib so they do not conflict with `reload4j` (`LogEventAdapter` VerifyError).
- Exclude transitive old `libthrift` and pin `libthrift` 0.16.0 to match Hive Metastore (`TSocket(TConfiguration,...)` NoSuchMethodError).
- Exclude obsolete `jline` from Sqoop and HCatalog sharelibs to avoid Beeline `jline-missing` when sharelibs are merged.

Fixes OCR-2571 packaging issues for ODP nightly 3.3.6.5.

## Test plan
- [x] `mvn -DskipTests package -pl sharelib/sqoop,sharelib/hcatalog -am` succeeds (JDK 11)
- [ ] Recreate Oozie ShareLib and confirm sqoop sharelib has no `log4j-1.2-api` / old `libthrift-0.9.x` / `jline-0.9.94`
- [ ] Re-run Verizon Teradata Sqoop + Hive2 workflow smoke


Made with [Cursor](https://cursor.com)