### PR TITLE
OCR-2572 - Bug - Exclude Log4j2 bridge, pin libthrift 0.16.0 and drop jline from Sqoop/HCatalog sharelibs

### DIFF
--- a/sharelib/hcatalog/pom.xml
+++ b/sharelib/hcatalog/pom.xml
@@ -69,6 +69,11 @@
                     <groupId>org.apache.thrift</groupId>
                     <artifactId>libthrift</artifactId>
                 </exclusion>
+                <!-- OCR-2571: jline 0.9.94 from Oozie BOM breaks Beeline when hcatalog is merged into hive2 -->
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper</artifactId>

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -84,6 +84,32 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <!-- OCR-2571: Log4j2 bridge + reload4j on same CP causes LogEventAdapter VerifyError -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-web</artifactId>
+                </exclusion>
+                <!-- OCR-2571: avoid shipping obsolete jline 0.9.94 into sqoop sharelib -->
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.mortbay.jetty</groupId>
                     <artifactId>jetty</artifactId>
                 </exclusion>
@@ -184,6 +210,13 @@
                     <artifactId>mina-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Align thrift with Hive Metastore (0.16.0) after excluding transitive old libthrift -->
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${libthrift.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
## Summary
- Exclude `log4j-1.2-api` / `log4j-api` / `log4j-core` / `log4j-web` (and `log4j-slf4j-impl`) from Sqoop sharelib to avoid `LogEventAdapter` VerifyError with `reload4j`.
- Pin `libthrift` to `${libthrift.version}` (0.16.0) after the existing transitive exclude.
- Exclude obsolete `jline` from Sqoop and HCatalog sharelibs to avoid Beeline `jline-missing` when sharelibs are merged.

Backport of OCR-2571 ShareLib packaging fix to `nightly/ODP-3.2.3.7-2`.

## Test plan
- [x] `mvn -DskipTests package -pl sharelib/sqoop,sharelib/hcatalog` succeeds (JDK 11)
- [ ] Recreate Oozie ShareLib and confirm sqoop has no `log4j-1.2-api` / old thrift / `jline-0.9.94`
- [ ] Smoke Sqoop + Hive2 workflow on 3.2.3.7-2


Made with [Cursor](https://cursor.com)